### PR TITLE
fix: postcss.atRule is not constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ module.exports = options => {
       });
 
       if (landscapeRules.length > 0) {
-        var landscapeRoot = new postcss.atRule({
+        var landscapeRoot = new postcss.AtRule({
           params: '(orientation: landscape)',
           name: 'media',
         });


### PR DESCRIPTION
## error
when `landscape: true`, there is an error like:
in vite 2.x: `postcss.atRule is not constructor`
in vite 3.x: `Cannot read properties of undefined (reading 'length')`

## reason
atRule is not a constructor in postcss 8.x
see: https://postcss.org/api/#postcss-atrule

## fix
replace `atRule` with `AtRule`


