### PR TITLE
fix 修复开启landscape后旧的css会重复插入bug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ const postcssPxToViewport = (options: OptionType) => {
 
   const pxRegex = getUnitRegexp(opts.unitToConvert);
   const satisfyPropList = createPropListMatcher(opts.propList);
-  const landscapeRules: AtRule[] = [];
+  let landscapeRules: AtRule[] = [];
 
   return {
     postcssPlugin: 'postcss-px-to-viewport',
@@ -189,6 +189,7 @@ const postcssPxToViewport = (options: OptionType) => {
           landscapeRoot.append(rule);
         });
         css.append(landscapeRoot);
+        landscapeRules = []
       }
     },
   };


### PR DESCRIPTION
在vue+vite项目中配置landscape: true后， 由于landscapeRules 一直没有重置，会导致landscapeRules 一直在叠加css样式。